### PR TITLE
[Footer/Nav][lg]: links are now dynamic -- refs #12

### DIFF
--- a/components/home/Footer.tsx
+++ b/components/home/Footer.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { dynamicPages } from './Nav';
 
-const Footer: React.FC = () => {
-  const navigation = {
+const Footer: React.FC<any> = ({ settings }) => {
+  const [navigation, setNavigation] = useState({
     menu: [
       { name: 'Datasets', href: '/search' },
       { name: 'Organizations', href: '/organization' },
@@ -13,7 +15,34 @@ const Footer: React.FC = () => {
       { name: 'Contact', href: '/p/contact' },
     ],
     social: [],
-  };
+  });
+
+  useEffect(() => {
+    const cmsNavigation = settings?.settings?.settings?.secondary_navigation
+      ?.map((nav) => {
+        // The URL can be absolute or relative
+        // Gets the last segment of the URL
+        let path;
+
+        if (nav.url.includes('//')) {
+          const tmp = /[^/]*\w*$/.exec(nav.url);
+          path = tmp.length > 0 ? tmp[0] : '';
+        } else path = nav.url;
+
+        path = path.replaceAll('/', '');
+        path = `${!dynamicPages.includes(path) ? '/p' : ''}/${path}`;
+
+        return {
+          name: nav.label,
+          href: path.length > 0 ? path : null,
+        };
+      })
+      .filter((el) => el.path != '');
+
+    if (cmsNavigation) {
+      setNavigation({ menu: cmsNavigation, social: [] });
+    }
+  }, [settings]);
 
   return (
     <footer className="relative overflow-hidden">

--- a/components/home/Layout.tsx
+++ b/components/home/Layout.tsx
@@ -1,8 +1,18 @@
+import { useQuery } from '@apollo/react-hooks';
 import Head from 'next/head';
+import { GET_CMS_SETTINGS } from '../../graphql/queries';
 import Footer from './Footer';
 import Nav from './Nav';
 
 export default function Layout({ children }) {
+  const {
+    data: settings,
+    loading,
+    error,
+  } = useQuery(GET_CMS_SETTINGS, {
+    notifyOnNetworkStatusChange: true,
+  });
+
   return (
     <>
       <Head>
@@ -12,9 +22,9 @@ export default function Layout({ children }) {
           content="initial-scale=1.0, width=device-width"
         />
       </Head>
-      <Nav />
+      <Nav settings={settings} />
       <main>{children}</main>
-      <Footer />
+      <Footer settings={settings} />
     </>
   );
 }

--- a/components/home/Nav.tsx
+++ b/components/home/Nav.tsx
@@ -1,13 +1,43 @@
+import { useEffect, useState } from 'react';
 import Template from './NavTemplate';
 
-const NavBar: React.FC = () => {
-  const navMenu = [
+export const dynamicPages = ['search', 'organization', 'topic', 'news'];
+
+const NavBar: React.FC<any> = ({ settings }) => {
+  const [navMenu, setNavMenu] = useState([
     { title: 'Datasets', path: '/search' },
     { title: 'Organizations', path: '/organization', matchExp: '/@' },
     { title: 'Topics', path: '/topic' },
     { title: 'Open Data 101', path: '/p/open-data-101' },
     { title: 'News', path: '/news' },
-  ];
+  ]);
+
+  useEffect(() => {
+    const cmsNavigation = settings?.settings?.settings?.navigation
+      ?.map((nav) => {
+        // The URL can be absolute or relative
+        // Gets the last segment of the URL
+        let path;
+
+        if (nav.url.includes('//')) {
+          const tmp = /[^/]*\w*$/.exec(nav.url);
+          path = tmp.length > 0 ? tmp[0] : '';
+        } else path = nav.url;
+
+        path = path.replaceAll('/', '');
+        path = `${!dynamicPages.includes(path) ? '/p' : ''}/${path}`;
+
+        return {
+          title: nav.label,
+          path: path.length > 0 ? path : null,
+        };
+      })
+      .filter((el) => el.path != '');
+
+    if (cmsNavigation) {
+      setNavMenu(cmsNavigation);
+    }
+  }, [settings]);
 
   return <Template menu={navMenu} logo={'/images/bayanat-logo.svg'} />;
 };

--- a/graphql/queries.ts
+++ b/graphql/queries.ts
@@ -312,6 +312,14 @@ export const GET_POST_QUERY = gql`
   }
 `;
 
+export const GET_CMS_SETTINGS = gql`
+  query settings {
+    settings @rest(type: "Settings", path: "settings", endpoint: "ghost") {
+      settings
+    }
+  }
+`;
+
 export const GET_POPULAR_DATASETS_QUERY = gql`
   query popular {
     popular @rest(type: "Search", path: "package_search?rows=3") {


### PR DESCRIPTION
## NOTE:
- I couldn't find a good way to make the links server-side rendered (we can't use getServerSideProps on non-page components and neither on _app.tsx)
- The data is fetched on the layout component, so it runs only once
- It's passed by properties to nav/footer
- Nav/Footer have default nav links in case the server is not responding
- Links can be fetched as absolute or relative URLs, so there's a treatment for that
- Links that are not specified as dynamic (see dynamicPages variable) have an /p/ appended at the start of the string