### PR TITLE
Card hover standardization

### DIFF
--- a/components/_shared/carousel/card/Card.tsx
+++ b/components/_shared/carousel/card/Card.tsx
@@ -14,14 +14,15 @@ const Card: React.FC<CardProps> = ({ title, icon, image }) => {
   return (
     <>
       <div className="relative w-full bg-gray-200 rounded-lg overflow-hidden group">
-        <div className="aspect-w-1 aspect-h-1 xl:aspect-w-7 xl:aspect-h-8">
+        <span className="absolute left-0 bottom-0 w-full h-full group-hover:border-b-4 border-[#22B373] rounded-b-l z-10" />
+        <div>
           <img
             src={image.url}
             alt={image.alt}
             className="w-full h-full object-center object-scale-down"
           />
         </div>
-        <div className="absolute py-4 bottom-0 inset-x-0 text-white text-sm pl-5 leading-4 flex justify-between group-hover:bg-slate-200 group-hover:opacity-75 group-hover:text-black">
+        <div className="absolute py-4 bottom-0 inset-x-0 text-white text-sm pl-5 leading-4 flex justify-between group-hover:bg-slate-200 group-hover:opacity-75 group-hover:text-black transition-all items-center">
           <h3 className="font-[Avenir] font-semibold">{title}</h3>
           {!!icon.url && (
             <div className="block overflow-hidden w-[35px] h-[35px] mr-4">

--- a/components/_shared/carousel/card/Card.tsx
+++ b/components/_shared/carousel/card/Card.tsx
@@ -22,8 +22,8 @@ const Card: React.FC<CardProps> = ({ title, icon, image }) => {
             className="w-full h-full object-center object-scale-down"
           />
         </div>
-        <div className="absolute py-4 bottom-0 inset-x-0 text-white text-sm pl-5 leading-4 flex justify-between group-hover:bg-slate-200 group-hover:opacity-75 group-hover:text-black transition-all items-center">
-          <h3 className="font-[Avenir] font-semibold">{title}</h3>
+        <div className="absolute py-4 bottom-0 inset-x-0 text-white text-m pl-5 leading-4 flex justify-between group-hover:bg-slate-200 group-hover:opacity-75 group-hover:text-black transition-all items-center">
+          <h3 className="font-avenir font-bold">{title}</h3>
           {!!icon.url && (
             <div className="block overflow-hidden w-[35px] h-[35px] mr-4">
               <img

--- a/components/home/main/Topics.tsx
+++ b/components/home/main/Topics.tsx
@@ -39,14 +39,14 @@ export default function Topics() {
               <a key={index} href={`/topic/${topic.name}`} className="group">
                 <div className="relative w-full bg-gray-200 rounded-lg overflow-hidden">
                   <span className="absolute left-0 bottom-0 w-full h-full group-hover:border-b-4 border-[#22B373] rounded-b-l z-10" />
-                  <div className="aspect-w-1 aspect-h-1 xl:aspect-w-7 xl:aspect-h-8">
+                  <div>
                     <img
                       src={topic.image_display_url}
                       alt={topic.title}
                       className="w-full h-full object-center object-scale-down"
                     />
                   </div>
-                  <p className="absolute py-4 bottom-0 inset-x-0 text-white text-sm text-center leading-4 font-poppins font-semibold group-hover:bg-slate-200 group-hover:opacity-75 group-hover:text-black">
+                  <p className="absolute py-4 bottom-0 inset-x-0 text-white text-sm text-center leading-4 font-poppins font-semibold group-hover:bg-slate-200 group-hover:opacity-75 group-hover:text-black transition-all">
                     {topic.title}
                   </p>
                 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,7 @@ module.exports = {
         raleway: ['raleway', 'sans-serif'],
         poppins: ['Poppins', 'sans-serif'],
         montserrat: ['Montserrat', 'sans-serif'],
+        avenir: ['avenir', 'sans-serif']
       },
       fontSize: {
         '3xl': '2.25rem',


### PR DESCRIPTION
## Notes:
- On the homepage: 
     - Changed the size of the card so that it fits the size of the image
     - Hover effect how has a smooth transition
- On the topics/orgs page:
     - The card now displays the correct font (Avenir)
     - Increased the size of the font a bit
     - Made the font bold
     - Increased the size of the icon a bit
     - The card now has a minimum height of 100px (See @abu-dhabi-agriculture-and-food-safety-authority to notice the reason for this, in this case the image was too short on height and the title would cover the whole card), if the image height is greater than this then the card just uses the image height. (not a perfect solution, but better than without it)
     - My intention was to make it more similar to the mockups
![ss-2022-08-25-14:17:56](https://user-images.githubusercontent.com/16550934/186729050-dab0a683-950c-4c25-95a6-f72a4de6a132.png)
With the minimum height:
![ss-2022-08-25-14:19:13](https://user-images.githubusercontent.com/16550934/186729334-e735bbd8-324d-48b8-826e-312536a2930b.png)
Without it:
![ss-2022-08-25-14:19:24](https://user-images.githubusercontent.com/16550934/186729337-9c2f4120-eb3b-4d47-93ea-89261ef4219d.png)
